### PR TITLE
Use `statusCode` and `statusMessage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,14 @@ const response = new Response({})
 
 > Extends `Servie` options.
 
-* `status?` The HTTP response status code (`number`)
-* `statusText?` The HTTP response status message (`string`)
+* `statusCode?` The HTTP response status code (`number`)
+* `statusMessage?` The HTTP response status message (`string`)
 
 #### Properties
 
-* `status?` The HTTP response status code (`number`)
-* `statusText?` The HTTP response status message (`string`)
+* `statusCode` The HTTP response status code (`number`)
+* `statusMessage?` The HTTP response status message (`string`)
+* `ok` Returns whether response was successful (status in range 200-299) (`boolean`)
 
 ### `Headers`
 

--- a/src/response.spec.ts
+++ b/src/response.spec.ts
@@ -1,15 +1,25 @@
 import { Response } from './response'
 
 describe('servie request', () => {
-  it('should support a status and status text', () => {
-    const res = new Response({ status: 200, statusText: 'Awesome job!' })
+  it('should create 200 responses by default', () => {
+    const res = new Response({ statusMessage: 'Awesome job!' })
 
-    expect(res.status).toBe(200)
-    expect(res.statusText).toBe('Awesome job!')
+    expect(res.statusCode).toBe(200)
+    expect(res.ok).toBe(true)
+    expect(res.statusMessage).toBe('Awesome job!')
+  })
+
+  it('should create custom status code responses', async () => {
+    const res = new Response({ statusCode: 404 })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.ok).toBe(false)
+    expect(res.statusMessage).toBe(undefined)
+    expect(await res.body.text()).toBe('')
   })
 
   it('should be able to clone', () => {
-    const res = new Response({ status: 201 })
+    const res = new Response({ statusCode: 201 })
     const resClone = new Response(res)
 
     expect(res).not.toBe(resClone)

--- a/src/response.ts
+++ b/src/response.ts
@@ -4,8 +4,8 @@ import { Servie, ServieOptions } from './base'
  * HTTP response class options.
  */
 export interface ResponseOptions extends ServieOptions {
-  status?: number
-  statusText?: string
+  statusCode?: number
+  statusMessage?: string
 }
 
 /**
@@ -13,20 +13,24 @@ export interface ResponseOptions extends ServieOptions {
  */
 export class Response extends Servie implements ResponseOptions {
 
-  status: number | undefined
-  statusText: string | undefined
+  statusCode: number
+  statusMessage?: string
 
-  constructor (options: ResponseOptions = {}) {
+  get ok () {
+    return this.statusCode >= 200 && this.statusCode < 300
+  }
+
+  constructor (options: ResponseOptions) {
     super(options)
 
-    this.status = options.status
-    this.statusText = options.statusText
+    this.statusCode = typeof options.statusCode === 'number' ? options.statusCode : 200
+    this.statusMessage = options.statusMessage
   }
 
   toJSON () {
     return {
-      status: this.status,
-      statusText: this.statusText,
+      statusCode: this.statusCode,
+      statusMessage: this.statusMessage,
       body: this.body.toJSON(),
       headers: this.headers.toJSON(),
       trailers: this.trailers.toJSON(),


### PR DESCRIPTION
Consistency with node.js and node.js-style errors instead of browsers.