### PR TITLE
Fix numeric header value treated as an array

### DIFF
--- a/src/headers.ts
+++ b/src/headers.ts
@@ -22,7 +22,13 @@ export class Headers {
     const prevValue = this.object[key];
     // tslint:disable-next-line
     if (prevValue === undefined) {
-      this.object[key] = typeof value === "string" ? value : value.map(String);
+      if (Array.isArray(value)) {
+        // tslint:disable-next-line
+        this.object[key] = value.map(String);
+      } else {
+        // tslint:disable-next-line
+        this.object[key] = value;
+      }
     } else if (Array.isArray(prevValue)) {
       if (Array.isArray(value)) {
         for (const v of value) prevValue.push(String(v));

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,6 +1,11 @@
-export type HeadersObject = Record<string, string | string[] | undefined>;
-export type HeaderTuple = [string, string | string[]];
-export type HeadersInit = Iterable<HeaderTuple> | HeadersObject | Headers;
+export type HeaderValue = string | string[];
+export type HeadersObject = Record<string, HeaderValue | undefined>;
+export type HeaderTuple = [string, HeaderValue];
+
+export type HeaderValueInput = number | string | Array<number | string>;
+export type HeadersObjectInput = Record<string, HeaderValueInput | undefined>;
+export type HeaderTupleInput = [string, HeaderValueInput];
+export type HeadersInit = Iterable<HeaderTupleInput> | HeadersObjectInput | Headers;
 
 /**
  * Map of HTTP headers.
@@ -12,22 +17,20 @@ export class Headers {
     if (init) this.extend(init);
   }
 
-  set(headerName: string, value: string | string[]): void {
+  set(headerName: string, value: HeaderValueInput): void {
     this.object[headerName.toLowerCase()] =
-      typeof value === "string" ? value : value.map(String);
+      Array.isArray(value) ? value.map(String) : String(value);
   }
 
-  append(headerName: string, value: string | string[]): void {
+  append(headerName: string, value: HeaderValueInput): void {
     const key = headerName.toLowerCase();
     const prevValue = this.object[key];
     // tslint:disable-next-line
     if (prevValue === undefined) {
       if (Array.isArray(value)) {
-        // tslint:disable-next-line
         this.object[key] = value.map(String);
       } else {
-        // tslint:disable-next-line
-        this.object[key] = value;
+        this.object[key] = String(value);
       }
     } else if (Array.isArray(prevValue)) {
       if (Array.isArray(value)) {
@@ -70,7 +73,7 @@ export class Headers {
     yield* Object.keys(this.object);
   }
 
-  *values(): IterableIterator<string | string[]> {
+  *values(): IterableIterator<HeaderValue> {
     yield* Object.values(this.object);
   }
 
@@ -78,7 +81,7 @@ export class Headers {
     this.object = Object.create(null);
   }
 
-  asObject(): Record<string, string | string[]> {
+  asObject(): HeadersObject {
     return Object.assign(Object.create(null), this.object);
   }
 

--- a/src/node.spec.ts
+++ b/src/node.spec.ts
@@ -3,7 +3,7 @@ import { Request, Response, Headers, AbortController } from "./node";
 describe("node", () => {
   describe("headers", () => {
     it("should init from an array", () => {
-      const headers = new Headers([["Number", 1]]);
+      const headers = new Headers([["Number", 1] as [string, number]]);
 
       expect(headers).not.toBe(headers);
       expect(headers.get("Number")).toEqual("1");
@@ -14,13 +14,15 @@ describe("node", () => {
       const headers = new Headers({
         Number: 1,
         String: "Two",
-        Array: ["One", "Two", "Three"],
+        Strings: ["One", "Two", "Three"],
         Numbers: [1, 2, 3]
       });
 
       expect(headers).not.toBe(headers);
       expect(headers.get("Number")).toEqual("1");
       expect(headers.get("String")).toEqual("Two");
+      expect(headers.get("Numbers")).toEqual("1");
+      expect(headers.get("Strings")).toEqual("One");
       expect(headers.get("Other")).toEqual(null);
     });
   });

--- a/src/node.spec.ts
+++ b/src/node.spec.ts
@@ -1,6 +1,30 @@
 import { Request, Response, Headers, AbortController } from "./node";
 
 describe("node", () => {
+  describe("headers", () => {
+    it("should init from an array", () => {
+      const headers = new Headers([["Number", 1]]);
+
+      expect(headers).not.toBe(headers);
+      expect(headers.get("Number")).toEqual("1");
+      expect(headers.get("Other")).toEqual(null);
+    });
+
+    it("should init from an object", () => {
+      const headers = new Headers({
+        Number: 1,
+        String: "Two",
+        Array: ["One", "Two", "Three"],
+        Numbers: [1, 2, 3]
+      });
+
+      expect(headers).not.toBe(headers);
+      expect(headers.get("Number")).toEqual("1");
+      expect(headers.get("String")).toEqual("Two");
+      expect(headers.get("Other")).toEqual(null);
+    });
+  });
+
   describe("request", () => {
     it("should contain base properties", () => {
       const req = new Request("/test");
@@ -11,27 +35,12 @@ describe("node", () => {
     });
 
     describe("headers", () => {
-      it("should accept instance of headers initialized by an array", () => {
-        const headers = new Headers([["Number", 1] as [any, any]]);
+      it("should accept instance of headers", () => {
+        const headers = new Headers([["Test", "1"]]);
         const req = new Request("/", { headers });
 
         expect(req.headers).not.toBe(headers);
-        expect(req.headers.get("Number")).toEqual(1);
-        expect(req.headers.get("Other")).toEqual(null);
-      });
-
-      it("should accept instance of headers initialized by an object", () => {
-        const headers = new Headers({
-          Number: 1,
-          String: "Two",
-          Array: ["One", "Two", "Three"],
-          Numbers: [1, 2, 3]
-        } as unknown as undefined);
-        const req = new Request("/", { headers });
-
-        expect(req.headers).not.toBe(headers);
-        expect(req.headers.get("Number")).toEqual(1);
-        expect(req.headers.get("String")).toEqual("Two");
+        expect(req.headers.get("Test")).toEqual("1");
         expect(req.headers.get("Other")).toEqual(null);
       });
 

--- a/src/node.spec.ts
+++ b/src/node.spec.ts
@@ -5,7 +5,6 @@ describe("node", () => {
     it("should init from an array", () => {
       const headers = new Headers([["Number", 1] as [string, number]]);
 
-      expect(headers).not.toBe(headers);
       expect(headers.get("Number")).toEqual("1");
       expect(headers.get("Other")).toEqual(null);
     });
@@ -18,7 +17,6 @@ describe("node", () => {
         Numbers: [1, 2, 3]
       });
 
-      expect(headers).not.toBe(headers);
       expect(headers.get("Number")).toEqual("1");
       expect(headers.get("String")).toEqual("Two");
       expect(headers.get("Numbers")).toEqual("1");

--- a/src/node.spec.ts
+++ b/src/node.spec.ts
@@ -36,7 +36,7 @@ describe("node", () => {
 
     describe("headers", () => {
       it("should accept instance of headers", () => {
-        const headers = new Headers([["Test", "1"]]);
+        const headers = new Headers([["Test", "1"] as [string, string]]);
         const req = new Request("/", { headers });
 
         expect(req.headers).not.toBe(headers);

--- a/src/node.spec.ts
+++ b/src/node.spec.ts
@@ -11,12 +11,27 @@ describe("node", () => {
     });
 
     describe("headers", () => {
-      it("should accept instance of headers", () => {
-        const headers = new Headers([["Test", "1"] as [string, string]]);
+      it("should accept instance of headers initialized by an array", () => {
+        const headers = new Headers([["Number", 1] as [any, any]]);
         const req = new Request("/", { headers });
 
         expect(req.headers).not.toBe(headers);
-        expect(req.headers.get("Test")).toEqual("1");
+        expect(req.headers.get("Number")).toEqual(1);
+        expect(req.headers.get("Other")).toEqual(null);
+      });
+
+      it("should accept instance of headers initialized by an object", () => {
+        const headers = new Headers({
+          Number: 1,
+          String: "Two",
+          Array: ["One", "Two", "Three"],
+          Numbers: [1, 2, 3]
+        } as unknown as undefined);
+        const req = new Request("/", { headers });
+
+        expect(req.headers).not.toBe(headers);
+        expect(req.headers.get("Number")).toEqual(1);
+        expect(req.headers.get("String")).toEqual("Two");
         expect(req.headers.get("Other")).toEqual(null);
       });
 


### PR DESCRIPTION
Issue #26 

Numeric header values such as "status: 200" trigger the error:
```/Projects/myapp/node_modules/servie/src/headers.ts:25
      this.object[key] = typeof value === "string" ? value : value.map(String);
                                                                   ^
TypeError: value.map is not a function
    at Headers.append (/Projects/myapp/node_modules/servie/src/headers.ts:25:68)```